### PR TITLE
Fix bug where message details would not update

### DIFF
--- a/src/components/MessagesView/MessagesView.tsx
+++ b/src/components/MessagesView/MessagesView.tsx
@@ -45,8 +45,8 @@ export default function MessagesView({
         text={message.text}
         fromSender
         onClick={() => {
-          setSelectedMessage(message);
           setModalVisible(true);
+          setSelectedMessage(message);
         }}
       />
     ) : (
@@ -62,8 +62,8 @@ export default function MessagesView({
             text={message.text}
             fromSender={false}
             onClick={() => {
-              setSelectedMessage(message);
               setModalVisible(true);
+              setSelectedMessage(message);
             }}
           />
         </div>
@@ -76,6 +76,10 @@ export default function MessagesView({
       </div>
     );
   });
+
+  const selectedMessageEncrypted = encryptedMessages.find(
+    message => message.id === selectedMessage?.id
+  );
 
   return (
     <>
@@ -90,26 +94,14 @@ export default function MessagesView({
         title={`Message Details (${selectedMessage?.text.slice(0, 14)}...)`}
         actions={<Button onClick={() => setModalVisible(false)}>Close</Button>}
       >
-        {(() => {
-          const message = encryptedMessages.find(message => message.id === selectedMessage?.id);
+        <p className={styles.WellLabel}>Ciphertext:</p>
+        <Well>{selectedMessageEncrypted?.data.m ?? ''}</Well>
 
-          if (!message) {
-            return null;
-          }
+        <p className={styles.WellLabel}>Initialization vector:</p>
+        <Well>{selectedMessageEncrypted?.data.iv ?? ''}</Well>
 
-          return (
-            <>
-              <p className={styles.WellLabel}>Ciphertext:</p>
-              <Well>{message.data.m}</Well>
-
-              <p className={styles.WellLabel}>Initialization vector:</p>
-              <Well>{message.data.iv}</Well>
-
-              <p className={styles.WellLabel}>Message authentication code:</p>
-              <Well>{message.hmac}</Well>
-            </>
-          );
-        })()}
+        <p className={styles.WellLabel}>Message authentication code:</p>
+        <Well>{selectedMessageEncrypted?.hmac ?? ''}</Well>
       </Modal>
     </>
   );


### PR DESCRIPTION
### What is the problem being solved in this PR?
Sometimes, when double clicking on multiple messages in sequence, the details containing the ciphertext would not update.  This PR fixes that.

### Related issues or PRs
N/A

### How did you accomplish this and why did you choose this approach?
- By adjusting the way that the contents of the modal is rendered, and changing the order of the state updates.

### How to test changes
1. Launch the server.
2. Send a few messages and double click on a few messages.  Each message should have different details in the details modal.

### Checklist
- [x] I've added the appropriate status labels to this PR, and I've self-assigned it.
- [x] I have tested my own changes locally.
- [x] If this changes any of the app's behaviour, I've made it easy for users to transition to the new behaviour.
- [x] I have added test cases, if needed.
- [ ] It is safe to revert these changes. That is, reverting this particular PR won't break anything.
